### PR TITLE
feat(actions): add dynamic README auto-update commit message

### DIFF
--- a/.github/workflows/rss-to-readme.yml
+++ b/.github/workflows/rss-to-readme.yml
@@ -57,7 +57,7 @@ jobs:
               -m "Generated at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
           Newly added posts:
-          ${{ steps.update_readme.outputs.added_titles }}"
+          ${{ steps.update_readme.outputs.added_links }}"
             git push origin HEAD:${GITHUB_REF_NAME}
           else
             echo "No README changes to commit"

--- a/.github/workflows/rss-to-readme.yml
+++ b/.github/workflows/rss-to-readme.yml
@@ -45,14 +45,19 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Update README
+        id: update_readme
         run: pnpm rss-to-readme
 
       - name: Commit and push if README changed
         run: |
           if ! git diff --quiet -- README.md; then
             git add README.md
-            git commit -S -m "Update README with latest articles [auto-generated]" \
-              -m "Generated at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+            git commit -S \
+              -m "Update README with ${{ steps.update_readme.outputs.added_count }} new article(s) [auto-generated]" \
+              -m "Generated at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+
+          Newly added posts:
+          ${{ steps.update_readme.outputs.added_titles }}"
             git push origin HEAD:${GITHUB_REF_NAME}
           else
             echo "No README changes to commit"

--- a/rss-to-readme.mjs
+++ b/rss-to-readme.mjs
@@ -59,20 +59,22 @@ const updateReadme = (content, newPosts) => {
   return `${content.replace(/\s*$/, '\n\n')}${newPosts}\n`;
 };
 
-const setGitHubOutputs = async (addedTitles) => {
+const setGitHubOutputs = async (addedEntries) => {
   const githubOutput = process.env.GITHUB_OUTPUT;
 
   if (!githubOutput) {
     return;
   }
 
-  const addedCount = String(addedTitles.length);
-  const addedTitlesBody =
-    addedTitles.length > 0 ? addedTitles.map((title) => `- ${title}`).join('\n') : '- None';
+  const addedCount = String(addedEntries.length);
+  const addedLinksBody =
+    addedEntries.length > 0
+      ? addedEntries.map(({ link }) => `- ${convertToHTTPS(link)}`).join('\n')
+      : '- None';
 
   await writeFile(
     githubOutput,
-    [`added_count=${addedCount}`, 'added_titles<<EOF', addedTitlesBody, 'EOF'].join('\n') + '\n',
+    [`added_count=${addedCount}`, 'added_links<<EOF', addedLinksBody, 'EOF'].join('\n') + '\n',
     { encoding: 'utf8', flag: 'a' },
   );
 };
@@ -99,16 +101,16 @@ const refreshReadme = async () => {
   const updatedReadme = updateReadme(readme, newPosts);
 
   const nextEntries = validEntries.slice(0, MAX_POSTS);
-  const addedTitles = nextEntries
-    .filter(({ link }) => !previousLinks.includes(convertToHTTPS(link)))
-    .map(({ title }) => title);
+  const addedEntries = nextEntries.filter(
+    ({ link }) => !previousLinks.includes(convertToHTTPS(link)),
+  );
 
-  await setGitHubOutputs(addedTitles);
+  await setGitHubOutputs(addedEntries);
 
   if (updatedReadme !== readme) {
     await writeFile(README_PATH, updatedReadme, 'utf8');
     console.log('README.md updated successfully');
-    console.log(`Newly added posts: ${addedTitles.length}`);
+    console.log(`Newly added posts: ${addedEntries.length}`);
   } else {
     console.log('No new blog posts. README.md was not updated.');
   }

--- a/rss-to-readme.mjs
+++ b/rss-to-readme.mjs
@@ -17,13 +17,29 @@ const POSTS_REGEX = new RegExp(
 
 const convertToHTTPS = (url) => url.replace(/^http:/i, 'https:');
 
+const getValidEntries = (entries) => entries.filter((entry) => entry?.title && entry?.link);
+
 const createPostsMarkdown = (entries, count) => {
-  const posts = entries
-    .filter((entry) => entry?.title && entry?.link)
+  const posts = getValidEntries(entries)
     .slice(0, count)
     .map(({ title, link }) => `- [${title}](${convertToHTTPS(link)})`);
 
   return [POSTS_HEADER, ...posts].join('\n');
+};
+
+const extractCurrentPostLinks = (content) => {
+  const match = content.match(POSTS_REGEX);
+
+  if (!match) {
+    return [];
+  }
+
+  return match[0]
+    .split('\n')
+    .slice(1)
+    .map((line) => line.match(/^- \[(.+?)\]\((.+?)\)$/)?.[2]?.trim())
+    .filter(Boolean)
+    .map(convertToHTTPS);
 };
 
 const updateReadme = (content, newPosts) => {
@@ -43,6 +59,24 @@ const updateReadme = (content, newPosts) => {
   return `${content.replace(/\s*$/, '\n\n')}${newPosts}\n`;
 };
 
+const setGitHubOutputs = async (addedTitles) => {
+  const githubOutput = process.env.GITHUB_OUTPUT;
+
+  if (!githubOutput) {
+    return;
+  }
+
+  const addedCount = String(addedTitles.length);
+  const addedTitlesBody =
+    addedTitles.length > 0 ? addedTitles.map((title) => `- ${title}`).join('\n') : '- None';
+
+  await writeFile(
+    githubOutput,
+    [`added_count=${addedCount}`, 'added_titles<<EOF', addedTitlesBody, 'EOF'].join('\n') + '\n',
+    { encoding: 'utf8', flag: 'a' },
+  );
+};
+
 const refreshReadme = async () => {
   const feed = await extract(RSS_URL, {
     xmlParserOptions: {
@@ -51,19 +85,30 @@ const refreshReadme = async () => {
   });
 
   const entries = feed?.entries ?? [];
+  const validEntries = getValidEntries(entries);
 
-  if (entries.length === 0) {
+  if (validEntries.length === 0) {
     console.log('No entries found in feed.');
+    await setGitHubOutputs([]);
     return;
   }
 
   const readme = await readFile(README_PATH, 'utf8');
-  const newPosts = createPostsMarkdown(entries, MAX_POSTS);
+  const previousLinks = extractCurrentPostLinks(readme);
+  const newPosts = createPostsMarkdown(validEntries, MAX_POSTS);
   const updatedReadme = updateReadme(readme, newPosts);
+
+  const nextEntries = validEntries.slice(0, MAX_POSTS);
+  const addedTitles = nextEntries
+    .filter(({ link }) => !previousLinks.includes(convertToHTTPS(link)))
+    .map(({ title }) => title);
+
+  await setGitHubOutputs(addedTitles);
 
   if (updatedReadme !== readme) {
     await writeFile(README_PATH, updatedReadme, 'utf8');
     console.log('README.md updated successfully');
+    console.log(`Newly added posts: ${addedTitles.length}`);
   } else {
     console.log('No new blog posts. README.md was not updated.');
   }


### PR DESCRIPTION
## Summary
- change the RSS-to-README script to detect newly added posts by link instead of title
- export the newly added post links through GitHub Actions outputs
- update the workflow commit body to include added article links instead of titles

## Why
Using links as the comparison key is more reliable than comparing titles.
It also makes the auto-generated commit body easier to verify because the exact added post URLs are shown directly.

## Example commit body
```
Generated at: 2026-03-18 06:00:00 UTC

Newly added posts:
- https://romantech.net/1350
- https://romantech.net/1349
```